### PR TITLE
Complete GPU Support

### DIFF
--- a/roles/deploy_jhub/files/cinder-kube-storage.yaml
+++ b/roles/deploy_jhub/files/cinder-kube-storage.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   name: cinder-storage
-provisioner: cinder.csi.openstack.org
-reclaimPolicy: Retain
+provisioner: kubernetes.io/cinder
 parameters:
   availability: ceph

--- a/roles/deploy_jhub/files/config.yaml.template
+++ b/roles/deploy_jhub/files/config.yaml.template
@@ -36,8 +36,8 @@ singleuser:
     limit: 2
     guarantee: 0.05
   memory:
-    limit: 1.5G
-    guarantee: 1.5G
+    limit: 1.8G
+    guarantee: 1.8G
 
   profileList:
     - display_name: "Default: Normal Size"
@@ -53,22 +53,22 @@ singleuser:
         mem_limit: "7.5G"
         mem_guaranttee: "7.5G"
         extra_resource_limits: {}
-    - display_name: "Not Available - GPU Prototype"
-      description: |
-        This configuration gives you 2 CPUs, 3GB of RAM, and a GPU
-      image: consideratio/singleuser-gpu:v0.3.0
-      kubespawner_override:
-        cpu_limit: 2
-        cpu_guarantee: 0.05
-        mem_limit: "3G"
-        mem_guarantee: "3G"
-        tolerations:
-          - key: nvidia.com/gpu
-            operator: Equal
-            value: "present"
-            effect: NoSchedule
-        extra_resource_limits:
-          nvidia.com/gpu: "1"
+    # - display_name: "GPU"
+    #   description: |
+    #     This configuration gives you 2 CPUs, 3GB of RAM, and a GPU
+    #   image: consideratio/singleuser-gpu:v0.3.0
+    #   kubespawner_override:
+    #     cpu_limit: 2
+    #     cpu_guarantee: 0.05
+    #     mem_limit: "3G"
+    #     mem_guarantee: "3G"
+    #     tolerations:
+    #       - key: nvidia.com/gpu
+    #         operator: Equal
+    #         value: "present"
+    #         effect: NoSchedule
+    #     extra_resource_limits:
+    #       nvidia.com/gpu: "1"
 
 hub:
   config:
@@ -80,7 +80,6 @@ hub:
       login_service: "IRIS IAM" # Name for the shiny button
       client_id: <TO_FILL>
       client_secret: <TO_FILL>
-      # Kept for reference but not a config item
       # registration_token: <TO_FILL>
       oauth_callback_url: https://jupyter.stfc.ac.uk/hub/oauth_callback
       authorize_url: https://iris-iam.stfc.ac.uk/authorize
@@ -94,12 +93,9 @@ hub:
         - groups
       username_key: preferred_username
     JupyterHub:
-      # Waiting on https://github.com/jupyterhub/oauthenticator/pull/395/files
-      # to uncomment this
+      # See below why this is commented out
       # authenticator_class: GroupAuth
   extraConfig:
-    # Adapted from https://github.com/jupyterhub/oauthenticator/pull/395/files
-    # When it's merged this can and should be removed
     custom_auth: |
       from typing import List
       from oauthenticator.generic import GenericOAuthenticator
@@ -112,6 +108,9 @@ hub:
           admin_groups: List[str] = [
               "stfc-cloud"
           ]
+
+          # Adapted from https://github.com/jupyterhub/oauthenticator/pull/395/files
+          # When it's merged this can and should be removed
 
           claim_groups_key = "groups"
           @staticmethod
@@ -158,9 +157,9 @@ scheduling:
   # Prep some environments beforehand so users don't have to wait
   userPlaceholder:
     enabled: true
-    replicas: 2 # Number of placeholders
+    replicas: 4 # Number of placeholders, this should eq high mem / default mem
 
 cull:
   enabled: true
-  timeout: 120
-  every: 30
+  timeout: 86400 # seconds == 1 day
+  every: 300 # 5 minutes

--- a/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
+++ b/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
@@ -26,8 +26,6 @@
       kube_dashboard_enabled: false
       auto_healing_enable: true
       auto_scaling_enabled: true
-      cloud_provider_enabled: true # required for cinder_csi
-      cinder_csi_enabled: true
       master_lb_floating_ip_enabled: true
       max_node_count: "{{ max_worker_nodes }}"
       container_infra_prefix: "{{ mirror_url }}"


### PR DESCRIPTION
This completes GPU support, and fixes a race condition, where the node has it's UUID label removed from CSI before CSI starts. This was fixed in upstream cinder but still present in Magnum cinder if we use the CSI framework. 

- For the moment we will stick with the deprecated (but supported) method of mounting a cinder provider.
- Comment out GPU profiles from the list and set the target number to 0, we can provide them but we want a slow release and ramp up instead of a surge