### PR TITLE
Fix cinder slow mounts

### DIFF
--- a/roles/deploy_jhub/files/cinder-kube-storage.yaml
+++ b/roles/deploy_jhub/files/cinder-kube-storage.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   name: cinder-storage
-provisioner: kubernetes.io/cinder
+provisioner: cinder.csi.openstack.org
+reclaimPolicy: Retain
 parameters:
   availability: ceph

--- a/roles/deploy_jhub/files/config-native-auth.yaml.template
+++ b/roles/deploy_jhub/files/config-native-auth.yaml.template
@@ -32,6 +32,7 @@ singleuser:
       storageClass: cinder-storage
 
   # Default profile, this is what the placeholders will use
+  startTimeout: 1200 # seconds == 20 minutes
   cpu:
     limit: 2
     guarantee: 0.05
@@ -42,16 +43,17 @@ singleuser:
   profileList:
     - display_name: "Default: Normal Size"
       description: |
-        For small jobs and prototyping: 2 CPUs, 1.5GB RAM and no GPU. This is the default.
+        For small jobs and prototyping: 2 CPUs, 1.5GB RAM and no GPU. This is the default, and will usually start in ~2 minutes. During periods of high-contention it may take up to 20 minutes to create.
       default: True
     - display_name: "Large Memory Instance"
       description: |
-        For larger jobs. 8 CPUs, 7.5GB RAM and no GPU.
+        For larger jobs. 8 CPUs, 7.5GB RAM and no GPU. This may
+        take up to 20 minutes to create.
       kubespawner_override:
         cpu_limit: 8
         cpu_guarantee: 0.05
         mem_limit: "7.5G"
-        mem_guaranttee: "7.5G"
+        mem_guarantee: "7.5G"
         extra_resource_limits: {}
     # - display_name: "GPU"
     #   description: |

--- a/roles/deploy_jhub/files/config-oauth.yaml.template
+++ b/roles/deploy_jhub/files/config-oauth.yaml.template
@@ -32,6 +32,7 @@ singleuser:
       storageClass: cinder-storage
 
   # Default profile, this is what the placeholders will use
+  startTimeout: 1200 # seconds == 20 minutes
   cpu:
     limit: 2
     guarantee: 0.05
@@ -42,16 +43,17 @@ singleuser:
   profileList:
     - display_name: "Default: Normal Size"
       description: |
-        For small jobs and prototyping: 2 CPUs, 1.5GB RAM and no GPU. This is the default.
+        For small jobs and prototyping: 2 CPUs, 1.5GB RAM and no GPU. This is the default, and will usually start in ~2 minutes. During periods of high-contention it may take up to 20 minutes to create.
       default: True
     - display_name: "Large Memory Instance"
       description: |
-        For larger jobs. 8 CPUs, 7.5GB RAM and no GPU.
+        For larger jobs. 8 CPUs, 7.5GB RAM and no GPU. This may
+        take up to 20 minutes to create.
       kubespawner_override:
         cpu_limit: 8
         cpu_guarantee: 0.05
         mem_limit: "7.5G"
-        mem_guaranttee: "7.5G"
+        mem_guarantee: "7.5G"
         extra_resource_limits: {}
     # - display_name: "GPU"
     #   description: |

--- a/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
+++ b/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
@@ -28,6 +28,8 @@
       kube_dashboard_enabled: false
       auto_healing_enable: true
       auto_scaling_enabled: true
+      cloud_provider_enabled: true # required for cinder_csi
+      cinder_csi_enabled: true
       master_lb_floating_ip_enabled: true
       max_node_count: "{{ max_worker_nodes }}"
       container_infra_prefix: "{{ mirror_url }}"


### PR DESCRIPTION
This fixes slow mounts in two commits:
- Use the new CSI plugin as it mounts in around 5 seconds instead of 120+ seconds
- Add a workaround whilst the fix I submitted upstream is backported (https://review.opendev.org/c/openstack/magnum/+/782527) for GPU instances not mounting cinder volumes.

See individual commits for more details