### PR TITLE
Bump default storage to 10GB

### DIFF
--- a/roles/deploy_jhub/files/config-native-auth.yaml.template
+++ b/roles/deploy_jhub/files/config-native-auth.yaml.template
@@ -27,7 +27,7 @@ singleuser:
         mountPath: /dev/shm
 
     type: dynamic
-    capacity: 1Gi # 1GB is the minimum Cinder will serve
+    capacity: 10Gi # 1GB is the minimum Cinder will serve
     dynamic:
       storageClass: cinder-storage
 

--- a/roles/deploy_jhub/files/config-oauth.yaml.template
+++ b/roles/deploy_jhub/files/config-oauth.yaml.template
@@ -27,7 +27,7 @@ singleuser:
         mountPath: /dev/shm
 
     type: dynamic
-    capacity: 1Gi # 1GB is the minimum Cinder will serve
+    capacity: 10Gi # 1GB is the minimum Cinder will serve
     dynamic:
       storageClass: cinder-storage
 


### PR DESCRIPTION
Bumps the default storage provided to users to 10GB, this allows us to
install JupyterLab extensions as 1GB is a bit too small.