### PR TITLE
Daskhub gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Provides a JupyterHub Service on an existing Openstack Cluster. This uses the he
 - [Deploying DaskHub](#deploying-daskhub)
   * [Variables (`/playbooks/deploy_daskhub.yml`)](#variables-playbooksdeploy_daskhubyml)
   * [Instructions](#instructions)
+  * [GPUs](#gpus)
   * [Troubleshooting](#troubleshooting)
 - [Prometheus Stack](#prometheus-stack)
   * [Accessing Grafana and Prometheus dashboard](#accessing-grafana-and-prometheus-dashboard)
@@ -234,6 +235,12 @@ Deploying DaskHub is similar to deploying JupyterHub, with a few minor differenc
 - Two load balancers will be created: `proxy_public` and `dask-gateway`, for JupyterHub and Dask Gateway respectively
   * A floating IPs must be associated with each of these load balancers while they are being created
 - Notebook images used must include dask-gateway
+
+### GPUs
+
+- A template `config.yaml` can be found in `roles/deploy_daskhub/config-gpu.yaml.template`
+- Ensure that the image used contains both the `dask_gateway` and `dask_cuda` packages, and that it matches in both locations in `config.yaml`
+- Ensure that the GPU operator has been successfully installed using `kubectl get pods -n gpu-operator`
 
 ### Troubleshooting
 

--- a/roles/deploy_daskhub/files/config-gpu.yaml.template
+++ b/roles/deploy_daskhub/files/config-gpu.yaml.template
@@ -16,6 +16,8 @@ jupyterhub:
     defaultUrl: "/lab"
     extraEnv:
       DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+      JUPYTERHUB_ACTIVITY_INTERVAL: "3600"
+    events: false
     image:
       name: <Image>  # Image to use for singleuser environment. Must include dask-gateway.
       tag: <Tag>
@@ -41,7 +43,7 @@ jupyterhub:
         storageClass: longhorn
 
     # Default profile, this is what the placeholders will use
-    startTimeout: 1200 # seconds == 20 minutes
+   startTimeout: 3600 # seconds == 60 minutes
     cpu:
       limit: 12
       guarantee: 1
@@ -76,7 +78,15 @@ jupyterhub:
         # Uncomment allowed_users and insert the list of user names allowed to sign-up using the same format as above, if required.
       JupyterHub:
         authenticator_class: nativeauthenticator.NativeAuthenticator
+    consecutiveFailureLimit: 0
     extraConfig:
+      myConfig: |
+        c.JupyterHub.activity_resolution = 6000
+        c.JupyterHub.last_activity_interval = 300
+        c.JupyterHub.init_spawners_timeout = 1
+        c.JupyterHub.concurrent_spawn_limit = 2000
+        c.KubeSpawner.k8s_api_threadpool_workers = c.JupyterHub.concurrent_spawn_limit
+        c.KubeSpawner.http_timeout = 60
       # Register Dask Gateway service and setup singleuser environment.
       # From https://github.com/dask/helm-chart/blob/main/daskhub/values.yaml
       00-add-dask-gateway-values: |
@@ -132,8 +142,9 @@ jupyterhub:
 
   cull:
     enabled: true
-    timeout: 86400 # seconds == 1 day
-    every: 300 # 5 minutes
+    timeout: 432000 # seconds == 5 day
+    every: 3600 # Run once an hour instead of every 10 minutes
+    concurrency: 1
 
 dask-gateway:
   enabled: true  # Enabling dask-gateway will install Dask Gateway as a dependency.

--- a/roles/deploy_daskhub/files/config-gpu.yaml.template
+++ b/roles/deploy_daskhub/files/config-gpu.yaml.template
@@ -1,0 +1,189 @@
+jupyterhub:
+  proxy:
+    https:
+      enabled: true
+      hosts:
+        - <Host Domain>
+      letsencrypt:
+        # Uncomment acmeserver for a test certificate
+        #acmeServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
+        # This email gets warnings if auto-renewal fails
+        contactEmail: <Not Set>
+    # This can be generated with `openssl rand -hex 32`
+    secretToken: <Not Set>
+
+  singleuser:
+    defaultUrl: "/lab"
+    extraEnv:
+      DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+    image:
+      name: <Image>  # Image to use for singleuser environment. Must include dask-gateway.
+      tag: <Tag>
+
+    storage:
+      # Required for PyTorch
+      extraVolumes:
+        - name: shm-volume
+          emptyDir:
+            medium: Memory
+        - name: training-materials
+          persistentVolumeClaim:
+            claimName: training-materials
+      extraVolumeMounts:
+        - name: shm-volume
+          mountPath: /dev/shm
+        - name: training-materials
+          mountPath: /mnt/materials
+
+      type: dynamic
+      capacity: 10Gi
+      dynamic:
+        storageClass: longhorn
+
+    # Default profile, this is what the placeholders will use
+    startTimeout: 1200 # seconds == 20 minutes
+    cpu:
+      limit: 12
+      guarantee: 1
+    memory:
+      limit: 1.8G
+      guarantee: 1.8G
+
+    profileList:
+      - display_name: "Dask GPU environment"
+        kubespawner_override:
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              effect: NoSchedule
+          extra_resource_limits:
+            nvidia.com/gpu: "1"
+        default: true
+
+  hub:
+    services:
+      dask-gateway:
+        apiToken: <Not Set>
+        display: false
+    config:
+      Authenticator:
+        admin_users:
+          - AdminUserAccountName
+        check_common_password: true
+        open_signup: true
+        allowed_users:
+          - Some Username
+        # Uncomment allowed_users and insert the list of user names allowed to sign-up using the same format as above, if required.
+      JupyterHub:
+        authenticator_class: nativeauthenticator.NativeAuthenticator
+    extraConfig:
+      # Register Dask Gateway service and setup singleuser environment.
+      # From https://github.com/dask/helm-chart/blob/main/daskhub/values.yaml
+      00-add-dask-gateway-values: |
+        # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.
+        # 2. Adds the URL for the Dask Gateway JupyterHub service.
+        import os
+        # These are set by jupyterhub.
+        release_name = os.environ["HELM_RELEASE_NAME"]
+        release_namespace = os.environ["POD_NAMESPACE"]
+        if "PROXY_HTTP_SERVICE_HOST" in os.environ:
+            # https is enabled, we want to use the internal http service.
+            gateway_address = "http://{}:{}/services/dask-gateway/".format(
+                os.environ["PROXY_HTTP_SERVICE_HOST"],
+                os.environ["PROXY_HTTP_SERVICE_PORT"],
+            )
+            print("Setting DASK_GATEWAY__ADDRESS {} from HTTP service".format(gateway_address))
+        else:
+            gateway_address = "http://proxy-public/services/dask-gateway"
+            print("Setting DASK_GATEWAY__ADDRESS {}".format(gateway_address))
+        # Internal address to connect to the Dask Gateway.
+        c.KubeSpawner.environment.setdefault("DASK_GATEWAY__ADDRESS", gateway_address)
+        # Internal address for the Dask Gateway proxy.
+        c.KubeSpawner.environment.setdefault("DASK_GATEWAY__PROXY_ADDRESS", "gateway://traefik-{}-dask-gateway.{}:80".format(release_name, release_namespace))
+        # Relative address for the dashboard link.
+        c.KubeSpawner.environment.setdefault("DASK_GATEWAY__PUBLIC_ADDRESS", "/services/dask-gateway/")
+        # Use JupyterHub to authenticate with Dask Gateway.
+        c.KubeSpawner.environment.setdefault("DASK_GATEWAY__AUTH__TYPE", "jupyterhub")
+        # Adds Dask Gateway as a JupyterHub service to make the gateway available at
+        # {HUB_URL}/services/dask-gateway
+        service_url = "http://traefik-{}-dask-gateway.{}".format(release_name, release_namespace)
+        for service in c.JupyterHub.services:
+            if service["name"] == "dask-gateway":
+                if not service.get("url", None):
+                    print("Adding dask-gateway service URL")
+                    service.setdefault("url", service_url)
+                break
+        else:
+            print("dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?")
+
+  scheduling:
+    # Try to pack users tightly rather than spinning up one node per user
+    userScheduler:
+      enabled: true
+    # Enable us to evict a placeholder rather than spin up a whole new node
+    podPriority:
+      enabled: true
+      defaultPriority: 0
+      userPlaceholderPriority: -10 # -10 is equal to scale up criteria
+    # Prep some environments beforehand so users don't have to wait
+    userPlaceholder:
+      enabled: true
+      replicas: 4 # Number of placeholders, this should eq high mem / default mem
+
+  cull:
+    enabled: true
+    timeout: 86400 # seconds == 1 day
+    every: 300 # 5 minutes
+
+dask-gateway:
+  enabled: true  # Enabling dask-gateway will install Dask Gateway as a dependency.
+  # Futher Dask Gateway configuration goes here
+  # See https://github.com/dask/dask-gateway/blob/master/resources/helm/dask-gateway/values.yaml
+  gateway:
+    prefix: "/services/dask-gateway"  # Users connect to the Gateway through the JupyterHub service.
+    auth:
+      type: jupyterhub  # Use JupyterHub to authenticate with Dask Gateway
+      jupyterhub:
+        apiToken: <Not Set>
+
+    extraConfig:
+    # From https://docs.dask.org/en/stable/deploying-kubernetes-helm.html#matching-the-user-environment
+      optionHandler: |
+        from dask_gateway_server.options import Options, Integer, Float, String
+        def option_handler(options):
+            if ":" not in options.image:
+                raise ValueError("When specifying an image you must also provide a tag")
+            return {
+                "image": options.image,
+            }
+        c.Backend.cluster_options = Options(
+        String("image", default="<Image:Tag>", label="Image"),
+            handler=option_handler,
+        )
+
+      cudaworker: |
+        c.ClusterConfig.worker_cmd = "dask-cuda-worker"
+
+    backend:
+      worker:
+        extraContainerConfig:
+          resources:
+            limits:
+              cpu: 6
+              memory: 7.5G
+              nvidia.com/gpu: 1
+            requests:
+              cpu: 2
+              memory: 2G
+              nvidia.com/gpu: 1
+
+  traefik:
+    service:
+      type: LoadBalancer
+
+dask-kubernetes:
+  # Use dask-kubernetes, rather than Dask Gateway, for creating Dask Clusters.
+  # Enabling this also requires
+  # 1. Setting `jupyterhub.singleuser.serviceAccountName: daskkubernetes`.
+  # 2. Ensuring that `dask-kubernetes` is in your singleuser environment.
+  enabled: false


### PR DESCRIPTION
Depends on #13.

Adds a new template for GPU support.

One of the largest difficulties appears to be pulling a suitable image, requiring both the `dask_gateway` and `dask_cuda` packages. It appears to be necessary to build a custom image. Starting points include:

- pangeo images, which include `dask_gateway`, but not `dask_cuda`
- rapidsai/rapidsai images, which include `dask_cuda`, but not `dask_gateway`, and lead to permission errors during spawning. See [here](https://github.com/kubeflow/kubeflow/blob/69fb4ec5909151a3089cb2ee6c2ab269c29f8636/components/contrib/rapidsai-notebook-image/Dockerfile#L56) for a possible solution?

Images similar to the kubeflow image linked above have been used to run GPUs successfully.

While functional, this configuration is relatively wasteful, requiring a GPU for each user's pod in addition to the workers.