### PR TITLE
Create scripts to create and delete FreeIPA users

### DIFF
--- a/scripts/create_users.py
+++ b/scripts/create_users.py
@@ -1,0 +1,40 @@
+from python_freeipa import ClientMeta
+import argparse
+from get_client import get_client
+
+
+def create_single_user(client: ClientMeta, user: str) -> None:
+    user = client.user_add(
+        a_uid=user,
+        o_givenname=user,
+        o_sn=user,
+        o_cn=user,
+        o_random=True,
+    )
+    print(user["result"]["uid"], user["result"]["randompassword"])
+
+
+def create_users(basename: str, start_index: int, end_index: int) -> None:
+    client = get_client()
+    for i in range(start_index, end_index + 1):
+        user = f"{basename}-{i}"
+        create_single_user(client, user)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--basename", help="User basename", type=str)
+    parser.add_argument("--first_index", help="First index for usernames", type=int)
+    parser.add_argument("--last_index", help="First index for usernames", type=int)
+    args = parser.parse_args()
+
+    basename = args.basename
+    first_index = args.first_index
+    last_index = args.last_index
+
+    create_users(basename, first_index, last_index)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/delete_users.py
+++ b/scripts/delete_users.py
@@ -1,0 +1,36 @@
+from python_freeipa import ClientMeta
+import argparse
+from get_client import get_client
+
+
+def delete_single_user(client: ClientMeta, user: str) -> None:
+    user = client.user_del(a_uid=user)
+    print(user["result"]["uid"], user["result"]["randompassword"])
+
+
+def delete_users(basename: str, start_index: int, end_index: int) -> None:
+    client = get_client()
+    users = []
+    for i in range(start_index, end_index + 1):
+        users.append(f"{basename}-{i}")
+    user = client.user_del(a_uid=users)
+    print(user["value"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--basename", help="User basename", type=str)
+    parser.add_argument("--first_index", help="First index for usernames", type=int)
+    parser.add_argument("--last_index", help="First index for usernames", type=int)
+    args = parser.parse_args()
+
+    basename = args.basename
+    first_index = args.first_index
+    last_index = args.last_index
+
+    delete_users(basename, first_index, last_index)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/freeipa_config.yml.template
+++ b/scripts/freeipa_config.yml.template
@@ -1,0 +1,4 @@
+hostname: <hostname>
+username: <username>
+password: <password>
+

--- a/scripts/get_client.py
+++ b/scripts/get_client.py
@@ -1,0 +1,14 @@
+from python_freeipa import ClientMeta
+import yaml
+
+
+def get_client() -> ClientMeta:
+    with open("freeipa_config.yml", "r") as stream:
+        freeipa_config = yaml.safe_load(stream)
+    hostname = freeipa_config["hostname"]
+    username = freeipa_config["username"]
+    password = freeipa_config["password"]
+    client = ClientMeta(hostname, verify_ssl=False)
+    client.login(username=username, password=password)
+    return client
+


### PR DESCRIPTION
Adds scripts to create and delete FreeIPA users of the form `<basename>-<index>`. The user creation script outputs the UIDs and passwords of each user, and the user deletion script outputs the UIDs of the deleted users.

Also includes a template config file, which is used to set the FreeIPA hostname, admin user and password.