### PR TITLE
BUG: Updates to JupyterHub version and disable user scheduling by default

### DIFF
--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -9,7 +9,7 @@
     NVIDIA_DRIVER_VERSION: 515.48.07
 
     # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
-    hub_version: "1.2.0"
+    hub_version: "3.1.0"
     # Name of JupyterHub cluster used in load balancer names
     hub_cluster_name: jupyterhub_cluster
     # K8s namespace

--- a/roles/deploy_jhub/files/config.yaml.template
+++ b/roles/deploy_jhub/files/config.yaml.template
@@ -88,7 +88,7 @@ hub:
 scheduling:
   # Try to pack users tightly rather than spinning up one node per user
   userScheduler:
-    enabled: true
+    enabled: false
   # Enable us to evict a placeholder rather than spin up a whole new node
   podPriority:
     enabled: true


### PR DESCRIPTION
- Update the JupyterHub version to `3.1.0`
- Noticed that when a user tries to spin up a server, the user pod fails to schedule onto a node. Setting the scheduling to `false` seems to fix this issue


**Note:** Should have #21 merged first before this is merged