### PR TITLE
MAINT: Update version of Longhorn to use

### DIFF
--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -8,6 +8,10 @@
     # This version will be pulled from the Nvidia NGC catalogue
     NVIDIA_DRIVER_VERSION: 515.48.07
 
+    # Longhorn repo
+    longhorn_version: "v1.5.2"
+    # longhorn_repo_name
+    longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
     # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
     hub_version: "3.1.0"
     # Name of JupyterHub cluster used in load balancer names

--- a/roles/deploy_hub/tasks/main.yml
+++ b/roles/deploy_hub/tasks/main.yml
@@ -23,11 +23,11 @@
     kind: Namespace
     state: present
 
-- name: Download Longhorn repo
+- name: Download Longhorn repos
   ansible.builtin.git:
-    repo: "https://github.com/longhorn/longhorn.git"
+    repo: "{{ longhorn_repo_name }}"
     dest: "/tmp/longhorn"
-    version: "v1.2.5"
+    version: "{{ longhorn_version }}"
     update: true # Automatically pull bug-fixes in
 
 - name: Install Longhorn prerequisites


### PR DESCRIPTION
The version of longhorn in the deploy_hub task is several minor versions behind. Updated the version to the latest which is v1.5.2 (as of 03/11/23)