### PR TITLE
BUG: Remove host domain variable

### DIFF
--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -3,19 +3,17 @@
     - deploy_hub
     # - deploy_prometheus_stack
   vars:
-    # Jupyterhub domain name
-    JUPYTER_DOMAIN_NAME: "example.com"
     # Even if you don't use GPUs we deploy the Nvidia GPU operator
     # for simplicity (otherwise we need another var to enable GPU support across notebooks).
     # This version will be pulled from the Nvidia NGC catalogue
     NVIDIA_DRIVER_VERSION: 515.48.07
 
     # Longhorn repo
-    longhorn_version: "v1.5.2"
+    longhorn_version: "v1.6.1"
     # longhorn_repo_name
     longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
     # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
-    hub_version: "3.3.2"
+    hub_version: "3.3.8"
     # Name of JupyterHub cluster used in load balancer names
     hub_cluster_name: jupyterhub_cluster
     # K8s namespace

--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -3,11 +3,6 @@
     - deploy_hub
     # - deploy_prometheus_stack
   vars:
-    # Even if you don't use GPUs we deploy the Nvidia GPU operator
-    # for simplicity (otherwise we need another var to enable GPU support across notebooks).
-    # This version will be pulled from the Nvidia NGC catalogue
-    NVIDIA_DRIVER_VERSION: 515.48.07
-
     # Longhorn repo
     longhorn_version: "v1.6.2"
     # longhorn_repo_name

--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -9,7 +9,7 @@
     NVIDIA_DRIVER_VERSION: 515.48.07
 
     # Longhorn repo
-    longhorn_version: "v1.6.1"
+    longhorn_version: "v1.6.2"
     # longhorn_repo_name
     longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
     # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)

--- a/roles/deploy_jhub/files/config-oauth.yaml.template
+++ b/roles/deploy_jhub/files/config-oauth.yaml.template
@@ -19,7 +19,7 @@ singleuser:
   defaultUrl: "/lab"
   extraEnv:
     JUPYTERHUB_ACTIVITY_INTERVAL: "3600"
-  events: false
+  events: true
 
   storage:
     # Required for PyTorch

--- a/roles/deploy_jhub/files/config-oauth.yaml.template
+++ b/roles/deploy_jhub/files/config-oauth.yaml.template
@@ -3,7 +3,7 @@ proxy:
   https:
     enabled: true
     hosts:
-      - "{{ JUPYTER_DOMAIN_NAME }}"
+      - <Host Domain>
     letsencrypt:
       # Uncomment acmeserver for a test certificate
       # acmeServer: "https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/roles/deploy_jhub/files/config.yaml.template
+++ b/roles/deploy_jhub/files/config.yaml.template
@@ -3,7 +3,7 @@ proxy:
   https:
     enabled: true
     hosts:
-      - "{{ JUPYTER_DOMAIN_NAME }}"
+      - <Host Domain>
     letsencrypt:
       # Uncomment acmeserver for a test certificate
       # acmeServer: "https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/roles/deploy_jhub/files/config.yaml.template
+++ b/roles/deploy_jhub/files/config.yaml.template
@@ -20,7 +20,7 @@ singleuser:
   defaultUrl: "/lab"
   extraEnv:
     JUPYTERHUB_ACTIVITY_INTERVAL: "3600"
-  events: false
+  events: true
 
   storage:
     # Required for PyTorch


### PR DESCRIPTION
Host domain variable is not working and returns 404 error when trying to get to jupyterhub page. The variable has been removed for now as it does not add to the ansible playbook.

This commit also updates the jupyterhub and longhorn versions.