### PR TITLE
ENH: Add values.yaml for configuring Longhorn

### DIFF
--- a/playbooks/deploy_jhub.yml
+++ b/playbooks/deploy_jhub.yml
@@ -7,6 +7,8 @@
     longhorn_version: "v1.6.2"
     # longhorn_repo_name
     longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
+    # config file for longhorn helm chart
+    longhorn_config_file: ../deploy_jhub/files/longhorn.yaml
     # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
     hub_version: "3.3.8"
     # Name of JupyterHub cluster used in load balancer names

--- a/roles/deploy_hub/tasks/main.yml
+++ b/roles/deploy_hub/tasks/main.yml
@@ -30,6 +30,8 @@
     chart_ref: longhorn/longhorn
     name: longhorn
     release_namespace: longhorn-system
+    values_files:
+      - "{{ role_path }}/{{ longhorn_config_file }}"
     update_repo_cache: yes
     release_values:
       taintToleration: "nvidia.com/gpu:NoSchedule"

--- a/roles/deploy_jhub/files/longhorn.yaml
+++ b/roles/deploy_jhub/files/longhorn.yaml
@@ -1,0 +1,14 @@
+defaultSettings:
+  taintToleration: "nvidia.com/gpu:NoSchedule"
+  snapshotMaxCount: 10
+  snapshotDataIntegrity: "enabled"
+  snapshotDataIntegrityCronjob: "0 12 * * 1"
+  replicaAutoBalance: "best-effort"
+  autoDeletePodWhenVolumeDetachedUnexpectedly: true
+  allowVolumeCreationWithDegradedAvailability: true
+  nodeDrainPolicy: "block-for-eviction"
+
+persistence:
+  defaultClassReplicaCount: 3
+  defaultDataLocality: disabled
+  migratable: "true"


### PR DESCRIPTION
Add a values.yaml file so we can change the rollout strategy to allow longhorn volumes to migrate better between nodes.

This has been tested on our test JupyterHub cluster