### PR TITLE
Hardcode admin names from CLOUD Group

### DIFF
--- a/group_vars/dev/all.yaml
+++ b/group_vars/dev/all.yaml
@@ -21,6 +21,10 @@ allowed_groups:
 # These get pre-pended with "admin-"
 # comment out admin, number_of_users, and username if using IAM
 admin_names:
+  - cgreen
+  - dfairbrother
+  - jcaballero
+  - moflynn
   - # name1
   - # name2
 number_of_users: # number of users to create

--- a/group_vars/prod/all.yaml
+++ b/group_vars/prod/all.yaml
@@ -20,6 +20,10 @@ allowed_groups:
 # These get pre-pended with "admin-"
 # comment out admin, number_of_users, and username if using IAM
 admin_names:
+  - cgreen
+  - dfairbrother
+  - jcaballero
+  - moflynn
   - # name1
   - # name2
 number_of_users: # number of users to create

--- a/group_vars/training/all.yaml
+++ b/group_vars/training/all.yaml
@@ -22,6 +22,10 @@ allowed_groups:
 # These get pre-pended with "admin-"
 # comment out admin, number_of_users, and username if using IAM
 admin_names:
+  - cgreen
+  - dfairbrother
+  - jcaballero
+  - moflynn
   - # name1
   - # name2
 number_of_users: # number of users to create


### PR DESCRIPTION
Let's hardcode the names of the members of the CLOUD Group that we always set as admin in all courses, so we don't need to add them manually every time.