### PR TITLE
Use tag to decouple roles execution

### DIFF
--- a/deploy_jhub.yml
+++ b/deploy_jhub.yml
@@ -1,6 +1,8 @@
 - hosts: all # Kubectl is configured from this machine
   roles:
     - deploy_jhub
+      tags:
+        - deploy_jhub
     - deploy_hub
-
-
+      tags:
+        - deploy_hub


### PR DESCRIPTION
Instead of always executing the tasks from both roles, deploy_hub and deploy_jhub, it would be nice to decide wich one each times. For example, when starting the cluster, we may not need to run the tasks for the deployment of the JupyterHub instance. Also, when setting up the JupyterHub instance (e.g. creating usernames), we may not want to rerun the steps to setup the cluster. The helm command may take too long.

One way to allow the execution of only one of the roles, if needed, is using tags.

With the new content in the playbook, we can now call it like this:

$ ansible-playbook deploy_jhub.yml

$ ansible-playbook deploy_jhub.yml --tags deploy_hub

$ ansible-playbook deploy_jhub.yml --tags deploy_jhub