### PR TITLE
BUG: Correct template indentation and add in missing variables

### DIFF
--- a/roles/deploy_jhub/templates/config.yaml.j2
+++ b/roles/deploy_jhub/templates/config.yaml.j2
@@ -55,37 +55,41 @@ singleuser:
 
   profileList:
   {% for profile in profiles %}
-    - display_name: "{{ profile.display_name }}"
-        description: |
-          "{{ profile.description }}"
-        default: {{ profile.default }}
-        kubespawner_override:
-          image: "{{ profile.image }}"
+   - display_name: "{{ profile.display_name }}"
+       description: |
+         "{{ profile.description }}"
+       image: consideratio/singleuser-gpu:v0.3.0
+       default: {{ profile.default }}
+       kubespawner_override:
+         image: {{ profile.image }}
+         cpu_limit: {{ profile.cpu_limit }}
+         cpu_guarantee: {{ profile.cpu_guarantee }}
+         mem_limit: "{{ profile.mem_limit }}"
+         mem_guarantee: "{{ profile.mem_guarantee }}"
+{% if profile.use_gpus is defined %}
+         tolerations:
+           - key: {{ profile.GPU_info.key }}
+             operator: {{ profile.GPU_info.operator }}
+             effect: {{ profile.GPU_info.effect }}
+         extra_resource_limits:
+            nvidia.com/gpu: "{{ profile.GPU_info.number_of_gpus}}"
+{% endif %}
 
-  {% if profile.use_gpus is defined %}
-        tolerations:
-          - key: {{ profile.GPU_info.key }}
-            operator: {{ profile.GPU_info.operator }}
-            effect: {{ profile.GPU_info.effect }}
-        extra_resource_limits:
-          nvidia.com/gpu: {{ profile.GPU_info.number_of_gpus}}
-  {% endif %}
-
-  {% if profile.commands is defined %}
-        lifecycle_hooks:
-            postStart:
-              exec:
-                command:
-                  - "bash"
-                  - "-c"
-                  - |
+  {% if (profile.commands | default([]) | select('truthy') | list) | length > 0 %}
+       lifecycle_hooks:
+           postStart:
+             exec:
+               command:
+                 - "bash"
+                 - "-c"
+                 - |
   {% for command in profile.commands %}
-                  {{ command }} || true
+                 {{ command }} || true
   {% endfor %}
   {% endif %}
 
   {% endfor %}
-
+  
 hub:
   config:
     Authenticator:


### PR DESCRIPTION
The template for config.yaml was missing variables that were required and there were missing indentations in the jinja template. This PR fixes these bugs.