### PR TITLE
MAINT: Remove extra quotation marks from template

### DIFF
--- a/roles/deploy_jhub/templates/config.yaml.j2
+++ b/roles/deploy_jhub/templates/config.yaml.j2
@@ -57,7 +57,7 @@ singleuser:
   {% for profile in profiles %}
    - display_name: "{{ profile.display_name }}"
        description: |
-         "{{ profile.description }}"
+         {{ profile.description }}
        image: consideratio/singleuser-gpu:v0.3.0
        default: {{ profile.default }}
        kubespawner_override:


### PR DESCRIPTION
A tiny update to remove the quotation marks from the config template as they are not needed.