### PR TITLE
Allow multiple username patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ sudo snap install helm --classic
     - `allowed_groups`: List of allowed iris iam groups to use for users
       </p>
     - `admin_names`: The admin usernames to be created (these will be prepended with `admin-`)
-    - `number_of_users`: The number of user accounts to be created
+    - `user_groups`: Mapping of username prefixes to the number of accounts to create. For example:
+      ```yaml
+      user_groups:
+        foo: 5
+        bar: 8
+      ```
     - `staging_cert`: whether to use acme to generate a staging cert
     - `nfs_ip`: The IP address of the nfs server
       </p>

--- a/group_vars/dev/all.yaml
+++ b/group_vars/dev/all.yaml
@@ -19,12 +19,14 @@ allowed_groups:
 
 # Admins and user accounts
 # These get pre-pended with "admin-"
-# comment out admin, number_of_users, and username if using IAM
+# comment out admin_names and user_groups if using IAM
 admin_names:
   - # name1
   - # name2
-number_of_users: # number of users to create
-username: # username style, that gets a number automatically added to the end
+user_groups:
+  # username: number of users to create
+  # foo: 5
+  # bar: 8
 
 staging_cert: true
 

--- a/group_vars/prod/all.yaml
+++ b/group_vars/prod/all.yaml
@@ -18,12 +18,14 @@ allowed_groups:
 
 # Admins and user accounts
 # These get pre-pended with "admin-"
-# comment out admin, number_of_users, and username if using IAM
+# comment out admin_names and user_groups if using IAM
 admin_names:
   - # name1
   - # name2
-number_of_users: # number of users to create
-username: # username style, that gets a number automatically added to the end
+user_groups:
+  # username: number of users to create
+  # foo: 5
+  # bar: 8
 
 # whether to use an acme server or not
 staging_cert: false

--- a/group_vars/training/all.yaml
+++ b/group_vars/training/all.yaml
@@ -20,12 +20,14 @@ allowed_groups:
 
 # Admins and user accounts
 # These get pre-pended with "admin-"
-# comment out admin, number_of_users, and username if using IAM
+# comment out admin_names and user_groups if using IAM
 admin_names:
   - # name1
   - # name2
-number_of_users: # number of users to create
-username: # username style, that gets a number automatically added to the end
+user_groups:
+  # username: number of users to create
+  # foo: 5
+  # bar: 8
 
 staging_cert: false
 

--- a/roles/deploy_jhub/templates/config.yaml.j2
+++ b/roles/deploy_jhub/templates/config.yaml.j2
@@ -132,11 +132,13 @@ hub:
       open_signup: false
       allowed_users:
   #  Weird indentation is expected in .j2 file
-{% set total_n_users = number_of_users | int %}
-{% set width_n_users = ("%d" % total_n_users).__len__() %}
-{% for i in range (1, (number_of_users | int) + 1) %}
-        - {{ username }}-{{ "%0*d" % (width_n_users, i) }}
-{% endfor %}
+{#  Weird indentation is expected in .j2 file #}
+{% for prefix, count in user_groups.items() %}
+{%   set width_n_users = ("%d" % (count | int)).__len__() %}
+{%   for i in range(1, (count | int) + 1) %}
+        - {{ prefix }}-{{ "%0*d" % (width_n_users, i) }}
+{%   endfor %}
+{% endfor %}  
 
     JupyterHub:
       authenticator_class: nativeauthenticator.NativeAuthenticator


### PR DESCRIPTION
Sometimes, the organisers requested the creation of 5 accounts with names "trainer-1" to "trainer-5", besides the rest of usernames with a different pattern.
Othertimes, we need to reuse the same profile for more than one course.

So, just in case something similar happens in the future, instead of allowing only a single username, we can user multiple patterns.

They are implemented as a dictionary underneath directory "group_vars", with format
  <prefix>: <number of users>

Then, we only need to loop over the pairs prefix:count in the Jinja2 template.

Also, use Jinja format for comments, so they do not show up in the final output.