### PR TITLE
Fixed bug with kubernetes python install

### DIFF
--- a/roles/deploy_hub/tasks/main.yml
+++ b/roles/deploy_hub/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Install kubernetes Ubuntu 24.04
   ansible.builtin.apt:
     name: python3-kubernetes
+  become: true
   when: ansible_distribution_major_version == "24"
 
 - name: Create Longhorn namespace


### PR DESCRIPTION
Added become: true to apt install python3-kubernetes task fails without this