### PR TITLE
Updated Longhorn and Jupyterhub versions

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,11 +1,11 @@
 contact_email: "SUPPORTANALYSIS@stfc.ac.uk"
 
 longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
-longhorn_version: "v1.11.1"
+longhorn_version: "v1.11.2"
 longhorn_config_file: ../longhorn/files/longhorn.yaml
 
 # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
-jhub_version: "4.3.3"
+jhub_version: "4.3.5"
 # Name of JupyterHub cluster used in load balancer names
 jhub_cluster_name: jupyterhub_cluster
 jhub_namespace: jupyterhub

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,11 +1,11 @@
 contact_email: "SUPPORTANALYSIS@stfc.ac.uk"
 
 longhorn_repo_name: "https://github.com/longhorn/longhorn.git"
-longhorn_version: "v1.9.0"
+longhorn_version: "v1.11.1"
 longhorn_config_file: ../longhorn/files/longhorn.yaml
 
 # Helm chart version for Jhub (newer version may require newer kubernetes version >=1.17)
-jhub_version: "4.2.0"
+jhub_version: "4.3.3"
 # Name of JupyterHub cluster used in load balancer names
 jhub_cluster_name: jupyterhub_cluster
 jhub_namespace: jupyterhub

--- a/roles/longhorn/tasks/main.yml
+++ b/roles/longhorn/tasks/main.yml
@@ -15,23 +15,6 @@
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
 
-- name: Download Longhorn repos
-  ansible.builtin.git:
-    repo: "{{ longhorn_repo_name }}"
-    dest: "/tmp/longhorn"
-    version: "{{ longhorn_version }}"
-    update: true # Automatically pull bug-fixes in
-
-- name: Install Longhorn prerequisites
-  kubernetes.core.k8s:
-    state: present
-    src: "{{ item }}"
-    namespace: longhorn-system
-    kubeconfig: "{{ kubeconfig_path }}"
-  with_items:
-    - "/tmp/longhorn/deploy/prerequisite/longhorn-iscsi-installation.yaml"
-    - "/tmp/longhorn/deploy/prerequisite/longhorn-nfs-installation.yaml"
-
 - name: Install Longhorn helm repo
   kubernetes.core.helm_repository:
     name: longhorn


### PR DESCRIPTION
Updated to more recent versions of Jupyterhub and longhorn.
Longhorn repos are no longer required in the newer version.

- Check by deploying from scratch with this branch
- Need to update to latest version oh Jupyterhub