### PR TITLE
Added support for manila shares

### DIFF
--- a/deploy_jhub.yml
+++ b/deploy_jhub.yml
@@ -11,6 +11,7 @@
     - longhorn
     - deploy_jupyterhub
     - restart_autohttps
-    - change_owner_of_manila_pod
+    - role: change_owner_of_manila_pod
+      when: manila.required == true
 
 

--- a/deploy_jhub.yml
+++ b/deploy_jhub.yml
@@ -11,5 +11,6 @@
     - longhorn
     - deploy_jupyterhub
     - restart_autohttps
+    - change_owner_of_manila_pod
 
 

--- a/group_vars/dev.yaml
+++ b/group_vars/dev.yaml
@@ -1,6 +1,7 @@
 host_domain: "test.jupyter.stfc.ac.uk"
 ip_address: "130.246.213.116"
 staging_cert: true
+kube_config: /home/{{ ansible_user_id }}/.kube/{{ cluster_name }}.kubeconfig
 
 admin_names:
   -
@@ -19,6 +20,11 @@ profiles:
     commands:
       -
       -
+
+manila:
+  required: false
+  mount_path: "/home/jovyan/manila"
+  share_name: new-cephfs-share-pvc
 
 iris_iam:
   required: false

--- a/group_vars/prod.yaml
+++ b/group_vars/prod.yaml
@@ -2,6 +2,7 @@ host_domain: "jupyter.stfc.ac.uk"
 ip_address: "130.246.213.94"
 longhorn_ip: "130.246.213.77"
 staging_cert: false
+kube_config: /home/{{ ansible_user_id }}/.kube/{{ cluster_name }}.kubeconfig
 
 admin_names:
   -
@@ -20,7 +21,11 @@ profiles:
     commands:
       -
       -
-
+manila:
+  required: false
+  mount_path: "/home/jovyan/manila"
+  share_name: new-cephfs-share-pvc
+  
 iris_iam:
   required: false
   client_id:

--- a/group_vars/prod.yaml
+++ b/group_vars/prod.yaml
@@ -21,6 +21,7 @@ profiles:
     commands:
       -
       -
+
 manila:
   required: false
   mount_path: "/home/jovyan/manila"

--- a/group_vars/training.yaml
+++ b/group_vars/training.yaml
@@ -21,6 +21,7 @@ profiles:
     commands:
       -
       -
+
 manila:
   required: false
   mount_path: "/home/jovyan/manila"

--- a/group_vars/training.yaml
+++ b/group_vars/training.yaml
@@ -2,6 +2,7 @@ host_domain: "training.jupyter.stfc.ac.uk"
 ip_address: "130.246.213.196"
 longhorn_ip: "130.246.213.143"
 staging_cert: false
+kube_config: /home/{{ ansible_user_id }}/.kube/{{ cluster_name }}.kubeconfig
 
 admin_names:
   -
@@ -20,6 +21,10 @@ profiles:
     commands:
       -
       -
+manila:
+  required: false
+  mount_path: "/home/jovyan/manila"
+  share_name: new-cephfs-share-pvc
 
 iris_iam:
   required: false

--- a/roles/change_owner_of_manila_pod/files/init_pod.yaml
+++ b/roles/change_owner_of_manila_pod/files/init_pod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: jupyterhub
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command: ["sh", "-c", "chown -R 1000:100 /home/jovyan/manila"]
+    securityContext:
+      runAsUser: 0
+      capabilities:
+        add: ["CHOWN"]
+    imagePullPolicy: IfNotPresent
+    name: busybox
+    volumeMounts:
+      - name: new-cephfs-share-pvc
+        mountPath: /home/jovyan/manila
+  volumes:
+    - name: new-cephfs-share-pvc
+      persistentVolumeClaim:
+        claimName: new-cephfs-share-pvc
+        readOnly: false
+  restartPolicy: Never

--- a/roles/change_owner_of_manila_pod/tasks/main.yaml
+++ b/roles/change_owner_of_manila_pod/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Copy over init pod
+  copy:
+    src: init_pod.yaml
+    dest: /home/{{ ansible_user_id }}/{{ cluster_name }}/init_pod.yaml
+
+- name: Apply init pod
+  ansible.builtin.command: kubectl apply -f /home/{{ ansible_user_id }}/{{ cluster_name }}/init_pod.yaml --kubeconfig {{ kube_config }}

--- a/roles/deploy_jupyterhub/templates/config.yaml.j2
+++ b/roles/deploy_jupyterhub/templates/config.yaml.j2
@@ -19,16 +19,28 @@ proxy:
 singleuser:
   # Use new UI by default as the old UI is being deprecated
   #  defaultUrl: "/lab"
-defaultUrl: "/lab"
+  defaultUrl: "/lab"
   extraEnv:
     JUPYTERHUB_ACTIVITY_INTERVAL: "3600"
   events: true
-
   storage:
     type: dynamic
     capacity: 10Gi
     dynamic:
       storageClass: longhorn
+{% if manila.required is true %}
+    extraVolumes:
+      - name: manila
+        persistentVolumeClaim:
+          claimName: {{ manila.share_name }}
+          namespace: default
+          readOnly: true
+    extraVolumeMounts:
+      - name: manila
+        mountPath: {{ manila.mount_path }}
+        readOnly: false
+{% endif %}
+
 
   # Default profile, this is what the placeholders will use
   startTimeout: 3600 # seconds == 60 minutes

--- a/roles/deploy_jupyterhub/templates/config.yaml.j2
+++ b/roles/deploy_jupyterhub/templates/config.yaml.j2
@@ -18,7 +18,6 @@ proxy:
 
 singleuser:
   # Use new UI by default as the old UI is being deprecated
-  #  defaultUrl: "/lab"
   defaultUrl: "/lab"
   extraEnv:
     JUPYTERHUB_ACTIVITY_INTERVAL: "3600"


### PR DESCRIPTION
This allows us to attach a pre-existing manila share to the Jupyterhub cluster as read only

Deployer adds in details of share to `<env>.yaml` file and playbook will attach existing manila share to Jupyterhub as read only