### PR TITLE
TST: ansible-lint on pre-commit not pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 ---
-default_install_hook_types:
-  - pre-commit
-  - pre-push
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -25,8 +21,6 @@ repos:
     rev: v25.9.2
     hooks:
       - id: ansible-lint
-        # Pre-push since this is a slow action
-        stages: [pre-push]
         args: ["--fix"]
         language_version: python3.11
         additional_dependencies:


### PR DESCRIPTION
I'd made it pre-push before since linting gets very slow and it interrupts my workflow. 

But this would match the behavior in daaas-ansible-platforms. I can just have a different personal setup.

Up to you.