### PR TITLE
BUG: Fix jhub lb name during destroy

### DIFF
--- a/roles/destroy_jupyterhub/tasks/main.yml
+++ b/roles/destroy_jupyterhub/tasks/main.yml
@@ -21,6 +21,6 @@
 - name: Delete jupyterhub loadbalancer
   openstack.cloud.loadbalancer:
     cloud: openstack
-    name: kube_service_{{ cluster_name }}_{{ jhub_deployed_name }}_proxy_public
+    name: kube_service_{{ cluster_name }}_{{ jhub_namespace }}_proxy-public
     state: absent
     delete_floating_ip: false


### PR DESCRIPTION
Should be i.e. `kube_service_jhub_jupyterhub_proxy-public`